### PR TITLE
new backend: naive

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You might also be interested in reading the [original design doc](https://docs.g
 
 The default backend is currently set to `overlayfs` and requires privileges
 since it is a lot more stable than the `fuse` backend.
+You can also use `naive` backend.
 
 * [Installation](#installation)
     - [Binaries](#binaries)

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var (
 
 	defaultStateDirectory = "/tmp/img"
 
-	validBackends = []string{defaultBackend, "fuse"}
+	validBackends = []string{defaultBackend, "fuse", "naive"}
 )
 
 func init() {
@@ -94,7 +94,7 @@ func main() {
 			// Build flag set with global flags in there.
 			fs := flag.NewFlagSet(name, flag.ExitOnError)
 			fs.BoolVar(&debug, "d", false, "enable debug logging")
-			fs.StringVar(&backend, "backend", defaultBackend, "backend for snapshots")
+			fs.StringVar(&backend, "backend", defaultBackend, fmt.Sprintf("backend for snapshots (%v)", validBackends))
 
 			// Register the subcommand flags in there, too.
 			command.Register(fs)

--- a/worker/runc/workeropt.go
+++ b/worker/runc/workeropt.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/containerd/diff/walking"
 	ctdmetadata "github.com/containerd/containerd/metadata"
 	ctdsnapshot "github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/naive"
 	"github.com/containerd/containerd/snapshots/overlay"
 	libfuse "github.com/hanwen/go-fuse/fuse"
 	"github.com/jessfraz/img/executor/runc"
@@ -52,6 +53,8 @@ func NewWorkerOpt(root, backend string) (opt base.WorkerOpt, fuseserver *libfuse
 		s, fuseserver, err = fuse.NewSnapshotter(filepath.Join(root, "snapshots"))
 	case "overlayfs":
 		s, err = overlay.NewSnapshotter(filepath.Join(root, "snapshots"))
+	case "naive":
+		s, err = naive.NewSnapshotter(filepath.Join(root, "snapshots"))
 	default:
 		return opt, nil, fmt.Errorf("%s is not a valid snapshots backend", backend)
 	}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

`naive` is the safest and maybe a good candidate for the default.

I'll open a buildkit PR to deduplicate the worker code across the both projects later (probably next week)
