### PR TITLE
fsutils: ensure rmdir gets set for every directory

### DIFF
--- a/fsutils/diff.go
+++ b/fsutils/diff.go
@@ -79,7 +79,7 @@ func doubleWalkDiff(ctx context.Context, changeFn fsutil.ChangeFunc, a, b walker
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if f1.f.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""


### PR DESCRIPTION
See upstream bug fix https://github.com/containerd/continuity/pull/103

This had an effect on buildkit output. I don't mind exporting some of these types of functions if you want to use them directly. Continuity is meant to be more general purpose fs utility package so we can add stuff there are specifically for build use cases (we would like to merge Tonis' fsutil package as well).