### PR TITLE
install img just like runc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Set an output prefix, which is the local directory if not specified
 PREFIX?=$(shell pwd)
+BINDIR := /usr/local/sbin
 
 # Setup name variables for the package/tool
 NAME := img
@@ -26,7 +27,7 @@ GO_LDFLAGS_STATIC=-ldflags "-w $(CTIMEVAR) -extldflags -static"
 # List the GOOS and GOARCH to build
 GOOSARCHES = linux/amd64
 
-all: clean build fmt lint test staticcheck vet install ## Runs a clean, build, fmt, lint, test, staticcheck, vet and install
+all: clean build fmt lint test staticcheck vet
 
 .PHONY: build
 build: $(NAME) ## Builds a dynamic executable or package
@@ -81,7 +82,7 @@ cover: ## Runs go test with coverage
 .PHONY: install
 install: ## Installs the executable or package
 	@echo "+ $@"
-	go install -a -tags "$(BUILDTAGS)" ${GO_LDFLAGS} .
+	install -D -m0755 $(NAME) $(BINDIR)/$(NAME)
 
 define buildpretty
 mkdir -p $(BUILDDIR)/$(1)/$(2);

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ You need to have `runc` installed.
 
 For the FUSE backend, you will also need `fusermount` installed.
 
+NOTE: These steps work only for Linux. Compile and run in a container (explained below) if you're on Windows or MacOS.
+
 #### Binaries
 
 - **linux** [amd64](https://github.com/jessfraz/img/releases/download/v0.2.4/img-linux-amd64)
@@ -101,7 +103,15 @@ For the FUSE backend, you will also need `fusermount` installed.
 $ go get github.com/jessfraz/img
 ```
 
-NOTE: Only works on Linux. Compile and run in a container (explained below) if you're on Windows or MacOS ;)
+#### From Source
+
+```bash
+$ mkdir -p $GOPATH/src/github.com/jessfraz
+$ git clone https://github.com/jessfraz/img $GOPATH/src/github.com/jessfraz/img
+$ cd !$
+$ make
+$ sudo make install
+```
 
 #### Running with Docker
 


### PR DESCRIPTION
This change will install img into /usr/local/sbin rather than $GOPATH/bin, which by default on most systems will be $HOME/go. This allows any user in the system (like root) access to the binary, as well as removing the extra step to re-compile `img` a second time (`go build && go install`).

This also removes the install step from `make all` due to the need for root privileges. Please let me know if you'd prefer to keep it as-is.