### PR TITLE
Pass empty root to walker in case we have no lower mounts

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -63,6 +63,15 @@ func TestBuildEnvironmentReplacementWorkdir(t *testing.T) {
   `))
 }
 
+func TestBuildFromScratch(t *testing.T) {
+	name := "testbuildfromscratch"
+
+	runBuild(t, name, withDockerfile(`
+  FROM scratch
+  COPY . .
+  `))
+}
+
 func TestBuildDockerfileNotInContext(t *testing.T) {
 	name := "testbuilddockerfilenotincontext"
 

--- a/diff/mount/temp.go
+++ b/diff/mount/temp.go
@@ -22,10 +22,13 @@ func WithTempMount(ctx context.Context, mounts []mount.Mount, f func(root string
 		}
 	}()*/
 
+	var root string
 	if len(mounts) > 1 {
 		return fmt.Errorf("mounts holds more than 1 mount, got %d: %#v", len(mounts), mounts)
 	}
-	root := mounts[0].Source
+	if len(mounts) == 1 {
+		root = mounts[0].Source
+	}
 
 	err := f(root)
 	if err != nil {


### PR DESCRIPTION
If building an image with `scratch` base, `img` panics due to lack of lower mount:
```Dockerfile
FROM alpine
FROM scratch
COPY --from=0 / /
````
```console
$ img build -t scratchy .
Building scratchy:latest
Setting up the rootfs... this may take a bit.
INFO[0000] resolving docker.io/tonistiigi/copy@sha256:476e0a67a1e4650c6adaf213269a2913deb7c52cbc77f954026f769d51e1a14e
INFO[0000] resolving docker.io/library/alpine@sha256:7b848083f93822dd21b0a2f14a110bd99f6efb4b838d499df6d04a49d0debf8b
INFO[0000] unpacking docker.io/library/alpine@sha256:7b848083f93822dd21b0a2f14a110bd99f6efb4b838d499df6d04a49d0debf8b
INFO[0001] unpacking docker.io/tonistiigi/copy@sha256:476e0a67a1e4650c6adaf213269a2913deb7c52cbc77f954026f769d51e1a14e
RUN [copy /src-0 /dest/]
--->
<--- nbypzzl5wqm5rmep5pppgeavk 0 <nil>
INFO[0001] exporting layers
panic: runtime error: index out of range

goroutine 235 [running]:
github.com/jessfraz/img/diff/mount.WithTempMount(0x118d180, 0xc4201973c0, 0x0, 0x0, 0x0, 0xc42049fb88, 0x10, 0x10)
        /go/src/github.com/jessfraz/img/diff/mount/temp.go:30 +0x2df
github.com/jessfraz/img/diff/walking.(*walkingDiff).Compare(0xc420331b10, 0x118d180, 0xc4201973c0, 0x0, 0x0, 0x0, 0xc420e21d40, 0x1, 0x1, 0xc420197fe0, ...)
        /go/src/github.com/jessfraz/img/diff/walking/differ.go:82 +0x362
github.com/jessfraz/img/vendor/github.com/moby/buildkit/cache/blobs.GetDiffPairs.func2.1(0x118d180, 0xc4201973c0, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/jessfraz/img/vendor/github.com/moby/buildkit/cache/blobs/blobs.go:74 +0x5be
github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol.(*call).run(0xc420e226c0)
        /go/src/github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol/flightcontrol.go:95 +0x65
github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol.(*call).(github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol.run)-fm()
        /go/src/github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol/flightcontrol.go:121 +0x2a
sync.(*Once).Do(0xc420e22718, 0xc42025a450)
        /usr/local/go/src/sync/once.go:44 +0xbe
created by github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol.(*call).wait
        /go/src/github.com/jessfraz/img/vendor/github.com/moby/buildkit/util/flightcontrol/flightcontrol.go:121 +0x1a5
```

This PR adds a check to avoid the panic and passes empty root to walker make a single walk (basically archiving lowest layer).