### PR TITLE
Fix image size calculation in 'list' command

### DIFF
--- a/client/list.go
+++ b/client/list.go
@@ -6,10 +6,18 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 )
 
+// ListedImage represents an image structure returuned from ListImages.
+// It extends containerd/images.Image with extra fields.
+type ListedImage struct {
+	images.Image
+	ContentSize int64
+}
+
 // ListImages returns the images from the image store.
-func (c *Client) ListImages(ctx context.Context, filters ...string) ([]images.Image, error) {
+func (c *Client) ListImages(ctx context.Context, filters ...string) ([]ListedImage, error) {
 	// Create the worker opts.
 	opt, err := c.createWorkerOpt()
 	if err != nil {
@@ -22,5 +30,13 @@ func (c *Client) ListImages(ctx context.Context, filters ...string) ([]images.Im
 		return nil, fmt.Errorf("listing images with filters (%s) failed: %v", strings.Join(filters, ", "), err)
 	}
 
-	return i, nil
+	listedImages := []ListedImage{}
+	for _, image := range i {
+		size, err := image.Size(ctx, opt.ContentStore, platforms.Default())
+		if err != nil {
+			return nil, fmt.Errorf("calculating size of image %s failed: %v", image.Name, err)
+		}
+		listedImages = append(listedImages, ListedImage{Image: image, ContentSize: size})
+	}
+	return listedImages, nil
 }

--- a/list.go
+++ b/list.go
@@ -57,7 +57,7 @@ func (cmd *listCommand) Run(args []string) (err error) {
 	for _, image := range images {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
 			image.Name,
-			units.BytesSize(float64(image.Target.Size)),
+			units.BytesSize(float64(image.ContentSize)),
 			units.HumanDuration(time.Now().UTC().Sub(image.CreatedAt))+" ago",
 			units.HumanDuration(time.Now().UTC().Sub(image.UpdatedAt))+" ago",
 			image.Target.Digest,


### PR DESCRIPTION
Previously it didn't walk through the layers and displayed the size only of the top descriptor.

NB: size returned by `containerd/images.Image.Size()` (this PR) is less than displayed by docker. Though it kinda matches with image sizes on Docker Hub and from `img save`. There are likely multiple sizes in fact but I don't know. :)
UPD: okay it seems I figured this out: `img du` displays image size on disk which matches with docker.